### PR TITLE
Added `gitignore` files for the `RProj` and for `config.txt`, 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,26 @@
 # History files
 .Rhistory
 .Rapp.history
-
 # Session Data files
 .RData
-
 # Example code in package build process
 *-Ex.R
-
 # Output files from R CMD build
 /*.tar.gz
-
 # Output files from R CMD check
 /*.Rcheck/
-
 # RStudio files
 .Rproj.user/
-
 # produced vignettes
 vignettes/*.html
 vignettes/*.pdf
-
 # OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
 .httr-oauth
-
 # knitr and R markdown default cache directories
 /*_cache/
 /cache/
-
 # Temporary files created by R markdown
 *.utf8.md
 *.knit.md
 .Rproj.user
+*.Rproj

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,1 @@
+config.txt


### PR DESCRIPTION
The `config.txt` file contains the private Translink API key.